### PR TITLE
Improve in-app documentation when not properly set up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 1.0.1
+- Added: changelog
+- Added: improperly configured front pages now give helpful errors and fix-it steps
+- Changed: updated documentation to clearer document setup process
+
+# 1.0
+- Initial release

--- a/README.md
+++ b/README.md
@@ -8,8 +8,26 @@ Please don't use without permission.
 
 ## Usage
 
-It assumes you have a static front page. It does not show any content from the
+This theme **assumes you have a static front page**. It does not show any content from the
 main WYSIWYG editor, instead showing all the sections from the form that appear
-beneath it.
+beneath it. If you haven't set this up properly, the theme will tell you how to fix it.
+
+This theme also **has a nav menu**. This menu only appears on pages (not the front page). The theme will not warn you if there is no nav menu, it just won't show anything. To add one:
+
+1. Open up a page (while logged in).
+2. Click **Customize**.
+3. Open **Menus**.
+4. **Add a menu**. Name it whatever you like. **Create Menu**.
+5. **Add Items** until you're satisfied.
+6. Under **Display Location**, select **Primary Navigation**.
+7. **Save & Publish**.
+
+This theme finally **includes a sidebar**. This is shown at the bottom of every page (including the front page) on the site. To modify it:
+
+1. Open up a page (while logged in).
+2. Click **Customize**.
+3. Open **Widgets**.
+4. Customize to your heart's content.
+5. Click **Save & Publish**.
 
 Create registration and callback pages yourself. See ACAPLUGIN for details.

--- a/front-page.php
+++ b/front-page.php
@@ -16,14 +16,71 @@
 </header>
 
 <?php while (have_posts()) : the_post(); ?>
-  <?php foreach (get_post_meta(get_the_id(), '_acac_section_group', true) as $key => $section): ?>
-  	<section class="section <?php echo ($section['dark']) ? 'section--dark' : ''; ?>">
+	<?php if (!is_page()): ?>
+	<section class="section">
 		<div class="section__wrapper">
 			<div class="section__content">
-				<h2><?php echo $section['title']; ?></h2>
-				<?php echo wpautop($section['content']); ?>
+				<h2>Configuration problems!</h2>
+				<p>
+					<strong>Error</strong>: This site expects a static homepage.
+				</p>
+				<p>If you are just trying to read this site, this is not your fault.</p>
+				<p>
+					This is a configuration error; this site is not configured properly to use
+					the ACAC theme.
+				</p>
+				<p>
+					Admins: you need to set up a static homepage.
+				</p>
+				<p>To do this:</p>
+				<ol>
+					<li>Log in.</li>
+					<li>Settings &gt; Reading</li>
+					<li>Set <strong>Front Page Displays</strong> to <strong>a static page</strong>.</li>
+					<li>Choose a page to be the "front" page and a page to be the "posts" page.</li>
+					<li>Click <strong>Save Changes</strong>.</li>
+				</ol>
 			</div>
 		</div>
 	</section>
-  <?php endforeach; ?>
+	<?php else: ?>
+		<?php $sections = get_post_meta(get_the_id(), '_acac_section_group', true); ?>
+		<?php if (!$sections || !array_key_exists('title', $sections[0])): ?>
+		<div class="section__wrapper">
+			<div class="section__content">
+				<h2>Configuration problems!</h2>
+				<p>
+					<strong>Error</strong>: The homepage needs <em>sections</em> of content.
+				</p>
+				<p>If you are just trying to read this site, this is not your fault.</p>
+				<p>
+					This is a configuration error; this site is not configured properly to use
+					the ACAC theme.
+				</p>
+				<p>
+					Admins: you need to add <em>sections</em> to the front page.
+					Regular content will not work.
+				</p>
+				<p>To do this:</p>
+				<ol>
+					<li>Log in.</li>
+					<li>Begin editing the front page.</li>
+					<li><em>Below</em> the main "content" editor, there is a box entitled <strong>Homepage sections</strong>. Add as many as you want.</li>
+					<li>Click <strong>Update</strong> on the right.</li>
+				</ol>
+			</div>
+		</div>
+		<?php else: ?>
+			<?php foreach ($sections as $key => $section): ?>
+				<section class="section <?php echo ($section['dark']) ? 'section--dark' : ''; ?>">
+				<div class="section__wrapper">
+					<div class="section__content">
+						<h2><?php echo $section['title']; ?></h2>
+						<?php echo wpautop($section['content']); ?>
+					</div>
+				</div>
+			</section>
+			<?php endforeach; ?>
+		<?php endif; ?>
+	<?php endif; ?>
 <?php endwhile; ?>

--- a/front-page.php
+++ b/front-page.php
@@ -6,7 +6,7 @@
 					<img class="logo__image" src="<?php bloginfo('template_directory'); ?>/assets/images/logo.svg" alt="the ACAC logo">
 				</a>
 			</h1>
-			
+
 			<hgroup class="tagline">
 				<h2 class="tagline__intro">a cappella is big at WUSTL.</h2>
 				<h2 class="tagline__emphasis">ACAC coordinates it.</h2>
@@ -17,59 +17,59 @@
 
 <?php while (have_posts()) : the_post(); ?>
 	<?php if (!is_page()): ?>
-	<section class="section">
-		<div class="section__wrapper">
-			<div class="section__content">
-				<h2>Configuration problems!</h2>
-				<p>
-					<strong>Error</strong>: This site expects a static homepage.
-				</p>
-				<p>If you are just trying to read this site, this is not your fault.</p>
-				<p>
-					This is a configuration error; this site is not configured properly to use
-					the ACAC theme.
-				</p>
-				<p>
-					Admins: you need to set up a static homepage.
-				</p>
-				<p>To do this:</p>
-				<ol>
-					<li>Log in.</li>
-					<li>Settings &gt; Reading</li>
-					<li>Set <strong>Front Page Displays</strong> to <strong>a static page</strong>.</li>
-					<li>Choose a page to be the "front" page and a page to be the "posts" page.</li>
-					<li>Click <strong>Save Changes</strong>.</li>
-				</ol>
+		<section class="section">
+			<div class="section__wrapper">
+				<div class="section__content">
+					<h2>Configuration problems!</h2>
+					<p>
+						<strong>Error</strong>: This site expects a static homepage.
+					</p>
+					<p>If you are just trying to read this site, this is not your fault.</p>
+					<p>
+						This is a configuration error; this site is not configured properly to use
+						the ACAC theme.
+					</p>
+					<p>
+						Admins: you need to set up a static homepage.
+					</p>
+					<p>To do this:</p>
+					<ol>
+						<li>Log in.</li>
+						<li>Settings &gt; Reading</li>
+						<li>Set <strong>Front Page Displays</strong> to <strong>a static page</strong>.</li>
+						<li>Choose a page to be the "front" page and a page to be the "posts" page.</li>
+						<li>Click <strong>Save Changes</strong>.</li>
+					</ol>
+				</div>
 			</div>
-		</div>
-	</section>
+		</section>
 	<?php else: ?>
 		<?php $sections = get_post_meta(get_the_id(), '_acac_section_group', true); ?>
 		<?php if (!$sections || !array_key_exists('title', $sections[0])): ?>
-		<div class="section__wrapper">
-			<div class="section__content">
-				<h2>Configuration problems!</h2>
-				<p>
-					<strong>Error</strong>: The homepage needs <em>sections</em> of content.
-				</p>
-				<p>If you are just trying to read this site, this is not your fault.</p>
-				<p>
-					This is a configuration error; this site is not configured properly to use
-					the ACAC theme.
-				</p>
-				<p>
-					Admins: you need to add <em>sections</em> to the front page.
-					Regular content will not work.
-				</p>
-				<p>To do this:</p>
-				<ol>
-					<li>Log in.</li>
-					<li>Begin editing the front page.</li>
-					<li><em>Below</em> the main "content" editor, there is a box entitled <strong>Homepage sections</strong>. Add as many as you want.</li>
-					<li>Click <strong>Update</strong> on the right.</li>
-				</ol>
+			<div class="section__wrapper">
+				<div class="section__content">
+					<h2>Configuration problems!</h2>
+					<p>
+						<strong>Error</strong>: The homepage needs <em>sections</em> of content.
+					</p>
+					<p>If you are just trying to read this site, this is not your fault.</p>
+					<p>
+						This is a configuration error; this site is not configured properly to use
+						the ACAC theme.
+					</p>
+					<p>
+						Admins: you need to add <em>sections</em> to the front page.
+						Regular content will not work.
+					</p>
+					<p>To do this:</p>
+					<ol>
+						<li>Log in.</li>
+						<li>Begin editing the front page.</li>
+						<li><em>Below</em> the main "content" editor, there is a box entitled <strong>Homepage sections</strong>. Add as many as you want.</li>
+						<li>Click <strong>Update</strong> on the right.</li>
+					</ol>
+				</div>
 			</div>
-		</div>
 		<?php else: ?>
 			<?php foreach ($sections as $key => $section): ?>
 				<section class="section <?php echo ($section['dark']) ? 'section--dark' : ''; ?>">

--- a/style.css
+++ b/style.css
@@ -1,12 +1,12 @@
 /*
 Theme Name:         ACAC Theme
-Theme URI:          TODO
+Theme URI:          https://github.com/citelao/acac-theme
 Description:        This theme is for the ACAC site only.
-Version:            0.0.1
+Version:            1.0.1
 Author:             Ben Stolovitz
 Author URI:         http://ben.stolovitz.com/
 Text Domain:        sage
 
 License:            Proprietary.
-License URI:        
+License URI:
 */

--- a/templates/header.php
+++ b/templates/header.php
@@ -7,7 +7,7 @@
       if (has_nav_menu('primary_navigation')) :
         wp_nav_menu(['theme_location' => 'primary_navigation', 'menu_class' => 'nav']);
       endif;
-      ?>ff
+      ?>
     </nav>
   </div>
 </header>

--- a/templates/header.php
+++ b/templates/header.php
@@ -7,7 +7,7 @@
       if (has_nav_menu('primary_navigation')) :
         wp_nav_menu(['theme_location' => 'primary_navigation', 'menu_class' => 'nav']);
       endif;
-      ?>
+      ?>ff
     </nav>
   </div>
 </header>


### PR DESCRIPTION
If the front page wasn't set up properly/didn't have sections, users saw opaque errors on the front page. These required code-spelunking to understand.

I replaced these errors with friendly, plaintext errors and instructions on how to fix them.